### PR TITLE
Add Sendable protocol to TaskQueue

### DIFF
--- a/Sources/SwiftTaskQueue/SwiftTaskQueue.swift
+++ b/Sources/SwiftTaskQueue/SwiftTaskQueue.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class TaskQueue{
+public class TaskQueue:Sendable {
     private class PendingTask{
         let label:String?
         var isCancelled = false


### PR DESCRIPTION
In many cases it's nice to create a global public `TaskQueue`, and for that it needs to be sendable.

I know this is a "cold PR", but I just stumbled upon your solution to this problem after making my own semaphore based version. And I liked yours a lot better, but ran straight into needing to make it sendable to support a global variable :-) - great work BTW, thank your for taking our time to polish and finish this.

It's not complete in any way, so this is a draft :-) I didn't want to just hi-jack with a ton of code.